### PR TITLE
fix: fix: correct typo in .profile by removing extra ']'

### DIFF
--- a/dotfiles/.profile
+++ b/dotfiles/.profile
@@ -20,4 +20,4 @@ fi
 [ -f "$HOME/.env" ] && . "$HOME/.env"
 
 # Source credentials
-[ -f "$HOME/.creds" ] && . "$HOME/.creds"]
+[ -f "$HOME/.creds" ] && . "$HOME/.creds"


### PR DESCRIPTION
## Fix: Ensure `.creds` file is sourced correctly.

This pull request fixes a minor typo in the `.profile` file that prevented the `.creds` file from being sourced correctly.

**Problem:**

The original line `[ -f "$HOME/.creds" ] && . "$HOME/.creds"]` had an extra `]` at the end, which caused a syntax error and prevented the `.creds` file from being sourced. This could lead to missing credentials and potentially broken workflows.

**Solution:**

This pull request removes the extra `]` from the line:

```diff
--- a/dotfiles/.profile
+++ b/dotfiles/.profile
@@ -20,4 +20,4 @@ fi
 [ -f "$HOME/.env" ] && . "$HOME/.env"

 # Source credentials
-[ -f "$HOME/.creds" ] && . "$HOME/.creds"]
\ No newline at end of file
+[ -f "$HOME/.creds" ] && . "$HOME/.creds"
```

Now the `.creds` file will be sourced correctly, ensuring that any credentials it contains are available in the