### PR TITLE
fix(env): disable Nvidia related settings in .env

### DIFF
--- a/dotfiles/.env
+++ b/dotfiles/.env
@@ -24,10 +24,10 @@ export HF_HUB_ENABLE_HF_TRANSFER=1
 # Bat theme: specify the theme for bat (if using bat for syntax highlighting)
 export BAT_THEME="Catppuccin Mocha"
 
-# Nvidia settings: set Video Codec SDK path and update PATH & LD_LIBRARY_PATH for CUDA/TensorRT
-export VIDEO_CODEC_SDK_PATH="$HOME/nvidia/video/codec/sdk"
-export PATH="/usr/local/cuda/bin:/usr/local/TensorRT-10.5.0.18/bin:$PATH"
-export LD_LIBRARY_PATH="/usr/lib/wsl/lib:/usr/local/cuda/lib64:/usr/local/TensorRT-10.5.0.18/lib:$LD_LIBRARY_PATH"
+## Nvidia settings: set Video Codec SDK path and update PATH & LD_LIBRARY_PATH for CUDA/TensorRT for manual tar.gz installations 
+# export VIDEO_CODEC_SDK_PATH="$HOME/nvidia/video/codec/sdk"
+# export PATH="/usr/local/cuda/bin:/usr/local/TensorRT-10.5.0.18/bin:$PATH"
+# export LD_LIBRARY_PATH="/usr/lib/wsl/lib:/usr/local/cuda/lib64:/usr/local/TensorRT-10.5.0.18/lib:$LD_LIBRARY_PATH"
 
 # Go configuration: add Go binaries if /usr/local/go/bin exists
 if [ -d "/usr/local/go/bin" ]; then


### PR DESCRIPTION
## Chore: Comment out Nvidia-specific environment variables

This pull request comments out the Nvidia-specific environment variables in the `.env` file.

**Reasoning:**

The current Nvidia settings assume a specific manual installation path for CUDA and TensorRT (e.g., `/usr/local/TensorRT-10.5.0.18`).  This is not a general solution and makes the dotfiles less portable. It also hardcodes a specific TensorRT version which will become outdated quickly.  By commenting these out, we remove this assumption and allow users to manage their Nvidia installations and environment variables independently.

**Changes:**

*   Commented out `VIDEO_CODEC_SDK_PATH`, `PATH`, and `LD_LIBRARY_PATH` related to Nvidia components in `.env`.
*   Added clarity in the comments that these configurations are intended for manual tar.gz installations.

**Benefits:**

*   **Improved Portability:** The dotfiles become more portable, as they no longer rely on a specific Nvidia setup.
*   **Flexibility:** Users have more control over their Nvidia installation and environment.
*   **Reduces potential conflicts:** Avoids conflicts with other installation