### PR TITLE
fix(configs): update ghostty and i3 configs for better usability

### DIFF
--- a/dotfiles/.config/ghostty/config
+++ b/dotfiles/.config/ghostty/config
@@ -25,6 +25,7 @@ shell-integration-features = no-cursor, title
 ## General Settings
 mouse-hide-while-typing = true
 confirm-close-surface = false
+gtk-single-instance=true
 # copy-on-select = clipboard
 
 ## Font Settings

--- a/dotfiles/.config/i3/config
+++ b/dotfiles/.config/i3/config
@@ -26,7 +26,7 @@ exec --no-startup-id xrdb -merge ~/.Xresources
 exec --no-startup-id dex --autostart --environment i3
 ## Lock screen before suspend
 exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock -c 000000 --nofork
-exec --no-startup-id xset s 1800
+exec --no-startup-id xset s off -dpms
 ## NetworkManager applet
 exec --no-startup-id nm-applet
 


### PR DESCRIPTION
## Pull Request: General Aesthetic and Functionality Improvements

This pull request introduces several quality-of-life and aesthetic improvements to my dotfiles configuration, focusing on enhancing user experience and system behavior.

**Key Changes:**

*   **Ghostty Configuration:** Added `gtk-single-instance=true` to the Ghostty configuration. This ensures only one instance of Ghostty runs, preventing accidental multiple terminal windows and improving resource management.
*   **i3 Configuration:** Modified the screen saver settings in the i3 configuration.  Replaced `xset s 1800` with `xset s off -dpms` to disable the screen saver entirely. This prevents the screen from blanking after a period of inactivity, which can be disruptive.

**Detailed Explanation:**

The Ghostty change addresses a potential nuisance where multiple Ghostty instances could be unintentionally launched. By enforcing a single instance, the user experience will be more consistent and predictable.

The i3 screen saver modification addresses a similar user annoyance. Eliminating unwanted screen blanking results in a smoother workflow, especially when referring to displayed information or during presentations.

**Code Changes:**

```diff
--- a/dotfiles/.config/ghostty/