### PR TITLE
feat: enable ctrl+number window switching in kitty/tmux

### DIFF
--- a/dotfiles/.config/kitty/kitty.conf
+++ b/dotfiles/.config/kitty/kitty.conf
@@ -18,6 +18,17 @@ shell_integration no-cursor
 # URL Handling
 open_url_with google-chrome
 
+# Ctrl+Number for tmux window switching (CSI u encoding)
+map ctrl+1 send_text all \x1b[49;5u
+map ctrl+2 send_text all \x1b[50;5u
+map ctrl+3 send_text all \x1b[51;5u
+map ctrl+4 send_text all \x1b[52;5u
+map ctrl+5 send_text all \x1b[53;5u
+map ctrl+6 send_text all \x1b[54;5u
+map ctrl+7 send_text all \x1b[55;5u
+map ctrl+8 send_text all \x1b[56;5u
+map ctrl+9 send_text all \x1b[57;5u
+
 # BEGIN_KITTY_THEME
 # Catppuccin-Mocha
 include current-theme.conf

--- a/dotfiles/.config/kitty/kitty.conf
+++ b/dotfiles/.config/kitty/kitty.conf
@@ -16,7 +16,7 @@ cursor_blink_interval 0
 shell_integration no-cursor
 
 # URL Handling
-open_url_with firefox
+open_url_with google-chrome
 
 # BEGIN_KITTY_THEME
 # Catppuccin-Mocha

--- a/dotfiles/.config/tmux/tmux.conf
+++ b/dotfiles/.config/tmux/tmux.conf
@@ -10,6 +10,8 @@ set -g @plugin 'catppuccin/tmux#v2.1.3'
 # prefix and general
 set -g default-terminal "tmux-256color"
 set -g allow-passthrough on
+set -s extended-keys on
+set -as terminal-features 'xterm-kitty:extkeys'
 unbind C-b
 unbind C-[
 
@@ -43,6 +45,17 @@ bind -r ">" swap-window -d -t +1
 bind -r ] next-window
 bind -r [ previous-window
 
+# Direct window switching with Ctrl+Number
+bind -n C-1 select-window -t 1
+bind -n C-2 select-window -t 2
+bind -n C-3 select-window -t 3
+bind -n C-4 select-window -t 4
+bind -n C-5 select-window -t 5
+bind -n C-6 select-window -t 6
+bind -n C-7 select-window -t 7
+bind -n C-8 select-window -t 8
+bind -n C-9 select-window -t 9
+
 # vertical and horizontal split
 # v, h swapped to match vim behaviour where vertical split means that the
 # separator will be vertical
@@ -52,6 +65,9 @@ unbind v
 unbind h
 bind V split-window -h -c "#{pane_current_path}"
 bind H split-window -v -c "#{pane_current_path}"
+
+# New window in current directory (Shift+C)
+bind C new-window -c "#{pane_current_path}"
 
 # move around splits
 bind-key h select-pane -L

--- a/dotfiles/.config/yazi/keymap.toml
+++ b/dotfiles/.config/yazi/keymap.toml
@@ -5,7 +5,7 @@ run = "plugin bunny"
 
 [[mgr.prepend_keymap]]
 on   = [ "i" ]
-run = "plugin searchjump"
+run = "plugin searchjump -- autocd"
 desc = "searchjump mode"
 
 # chmod.yazi - Change file permissions

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -163,13 +163,12 @@ fi
 zz() {
   local dir
   dir=$(
-    zoxide query --list --separator "\0" \
-    | fzf --read0 --print0 \
+    zoxide query --list \
+    | fzf \
         --height=40% \
         --reverse \
         --ansi \
-        --preview 'ls -la --color=always -- "{}"' \
-    | tr -d '\0'
+        --preview 'ls -la --color=always -- {}' \
   ) || return 1
 
   [ -n "$dir" ] && z "$dir"
@@ -179,13 +178,12 @@ zz() {
 zf() {
   local file
   file=$(
-    fd --type f --print0 \
-    | fzf --read0 --print0 \
+    fd --type f \
+    | fzf \
         --height=40% \
         --reverse \
         --ansi \
-        --preview 'bat --color=always --style=numbers --line-range=:500 -- "{}"' \
-    | tr -d '\0'
+        --preview 'bat --color=always --style=numbers --line-range=:500 -- {}' \
   ) || return 1
 
   [ -n "$file" ] && ${EDITOR:-vim} "$file"

--- a/setup.sh
+++ b/setup.sh
@@ -369,6 +369,7 @@ install_essential_packages() {
         iperf3
         aria2
         wireplumber
+        libfuse2
     )
 
     # Install all packages

--- a/setup.sh
+++ b/setup.sh
@@ -1188,7 +1188,7 @@ setup_shell_environment() {
 
     # Install 'yazi' file manager
     if [ ! -x "$(command -v yazi)" ]; then
-        run_silent $HOME/.cargo/bin/cargo install --locked yazi-fm yazi-cli
+        run_silent $HOME/.cargo/bin/cargo install --locked yazi-build
         print_status "install yazi"
     else
         print_status "install yazi" skip

--- a/utils/bin/ff
+++ b/utils/bin/ff
@@ -14,12 +14,12 @@ typeset selected=($(
     --ansi \
     --disabled \
     --reverse \
-    --height=50% \
+    --height=40% \
     --layout=reverse \
     --border \
     --print-query \
     --bind "change:reload:$RG_DEFAULT_COMMAND {q} || true" \
-    --preview "rg -i --color=always --context=2 --hidden --glob '!.git' {q} {}" \
+    --preview "bat --color=always --style=numbers --line-range=:300 {} 2>/dev/null || rg -i --color=always --context=3 --hidden --glob '!.git' {q} {} | head -100" \
     --preview-window=right:60%:wrap))
 
 [ -n "${selected[1]}" ] && ${EDITOR:-vim} -c "/\\c${selected[0]}" "${selected[1]}"


### PR DESCRIPTION
### Overview
This Pull Request introduces significant quality-of-life improvements for terminal usage, focusing primarily on enhancing window switching within Tmux when running inside Kitty, and refining interactive file searching utilities (`fzf`, `zoxide`, `fd`). It also includes necessary maintenance updates for package dependencies and application installation methods.

### Key Changes

**Terminal Configuration (`kitty.conf`, `tmux.conf`):**
*   Implemented direct, non-prefixed Ctrl+Number window switching (1-9) in Tmux when using Kitty. This utilizes Kitty's CSI u extended key encoding.
*   Enabled extended keys (`extended-keys on`) and set terminal features in Tmux to support the new key mappings.
*   Switched the default URL handler in Kitty from `firefox` to `google-chrome`.
*   Added a new Tmux binding (`bind C`) to create a new window in the current pane's directory.

**Shell Utilities (`.zshrc`, `utils/bin/ff`):**
*   Simplified the `zz` (zoxide) and `zf` (fd) functions in `.zshrc` by removing the use of null-byte separation (`--read0`, `--print0`, `tr -d '